### PR TITLE
Makefile corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 CC=g++
-CFLAGS=-I/usr/lib/x86_64-linux-gnu/wx/include/gtk2-unicode-3.0-unofficial -I/usr/include/wx-3.0-unofficial -D_FILE_OFFSET_BITS=64 -D__WXGTK__ -pthread -Wall -O2 -c
-CRYPTOPP=../cryptopp562/libcryptopp.a
+CFLAGS=-I/usr/lib/x86_64-linux-gnu/wx/include/gtk2-unicode-3.0 -I/usr/include/wx-3.0 -D_FILE_OFFSET_BITS=64 -D__WXGTK__ -pthread -Wall -O2 -c
+CRYPTOPP=-lcryptopp
 
 build:
-	$(CC) $(CFLAGS) /home/ilya/Projects/Entangle/EntangleApp.cpp -o EntangleApp.o
+	$(CC) $(CFLAGS) EntangleApp.cpp -o EntangleApp.o
 
-	$(CC) $(CFLAGS) /home/ilya/Projects/Entangle/EntangleMain.cpp -o EntangleMain.o
+	$(CC) $(CFLAGS) EntangleMain.cpp -o EntangleMain.o
 
-	$(CC) -o Entangle EntangleApp.o EntangleMain.o  -s -L/usr/lib/x86_64-linux-gnu -pthread -lwx_gtk2u_unofficial_core-3.0 -lwx_baseu_unofficial-3.0   $(CRYPTOPP)
+	$(CC) -o Entangle EntangleApp.o EntangleMain.o  -s -L/usr/lib/x86_64-linux-gnu -pthread -lwx_gtk2u_core-3.0 -lwx_baseu-3.0   $(CRYPTOPP)
 install:
 	install Entangle /usr/local/bin
 uninstall:


### PR DESCRIPTION
The `Makefile` had some mistakes. Firstly, source file names where absolute, but should be given relative to root directory of repository. Secondly, paths to include and library directories where incorrect.
To have everything compiled successfully you should install the following dependencies:
* `libwxgtk3.0` and `libwxgtk3.0-dev`
* `libcrypto++9` and `libcrypto++-dev`

I recommend to put information about dependencies in `README.md`, if you like.